### PR TITLE
platform: add junit guard to ensure no junit classpath in the build

### DIFF
--- a/app/src/main/java/com/boot/autoworkflow/App.kt
+++ b/app/src/main/java/com/boot/autoworkflow/App.kt
@@ -5,6 +5,6 @@ import android.app.Application
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        if(hasJunit()) error("!!!Alert!!! Has junit in the build")
+//        if(hasJunit()) error("!!!Alert!!! Has junit in the build")
     }
 }

--- a/app/src/main/java/com/boot/autoworkflow/App.kt
+++ b/app/src/main/java/com/boot/autoworkflow/App.kt
@@ -2,4 +2,9 @@ package com.boot.autoworkflow
 
 import android.app.Application
 
-class App: Application()
+class App : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        if(hasJunit()) error("!!!Alert!!! Has junit in the build")
+    }
+}

--- a/app/src/main/java/com/boot/autoworkflow/JunitGuard.kt
+++ b/app/src/main/java/com/boot/autoworkflow/JunitGuard.kt
@@ -1,0 +1,8 @@
+package com.boot.autoworkflow
+
+fun hasJunit() = try {
+    Class.forName("org.junit.Test")
+    true
+} catch (allGood: Throwable) {
+    false
+}


### PR DESCRIPTION
There are two ways to check:
1. Runtime check in this PR
---

2. Compile check via following command:
```
./gradlew :app:dependencies --configuration releaseRuntimeClasspath | grep -e test -e junit
```
Note that. Must disable configuation cache before run above command.
```
org.gradle.unsafe.configuration-cache=false
```
